### PR TITLE
Add support for using Cake.Docker on Linux machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Including addin in cake script is easy.
 ```
 ## Commands supported
 
+- [DockerLogin](https://docs.docker.com/engine/reference/commandline/login/) v0.4.0
+- [DockerPush](https://docs.docker.com/engine/reference/commandline/push/) v0.4.0
+- [DockerTag](https://docs.docker.com/engine/reference/commandline/tag/) v0.4.0
 - [DockerPs](https://docs.docker.com/engine/reference/commandline/ps/) v0.3.0
 - [DockerRm](https://docs.docker.com/engine/reference/commandline/rm/)
 - [DockerRmi](https://docs.docker.com/engine/reference/commandline/rmi/)
@@ -51,6 +54,8 @@ All come with settings argument and support all settings except for DockerBuild 
 **This is an initial version and not tested thoroughly**.
 Contributions welcome.
 
-Tested only on Windows. I guess it should work on Linux, too, assuming a proper docker exe name is added.
+Tested only on Windows and Ubuntu. Ensure that Docker command line tool can be located using the PATH (e.g. check that it can be found with `which docker`).
+On Linux machines, ensure that user has access to the `docker` daemon Unix socket or use the DOCKER_HOST environment variable to point to the daemon's TCP port.
+Refer to the Docker documentation for controlling access to the docker daemon Unix socket.
 
 [![Follow @mihamarkic](https://img.shields.io/badge/Twitter-Follow%20%40mihamarkic-blue.svg)](https://twitter.com/intent/follow?screen_name=mihamarkic)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+# Cake.Docker 0.4.0
+- Added support for using the package on Linux machines.
+- Added [DockerLogin](https://docs.docker.com/engine/reference/commandline/login/)
+- Added [DockerPush](https://docs.docker.com/engine/reference/commandline/push/)
+- Added [DockerTag](https://docs.docker.com/engine/reference/commandline/tag/)
+
 # Cake.Docker 0.3.0
 - Added [DockerPs](https://docs.docker.com/engine/reference/commandline/ps/)
     - ports aren't included, size is approximate, created date is in text format, exited data is not included

--- a/src/Cake.Docker/Cake.Docker.csproj
+++ b/src/Cake.Docker/Cake.Docker.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Create\DockerCreateSettings.cs" />
     <Compile Include="Cp\Docker.Aliases.Cp.cs" />
     <Compile Include="DockerResolver.cs" />
+    <Compile Include="Login\Docker.Aliases.Login.cs" />
+    <Compile Include="Login\DockerLoginSettings.cs" />
     <Compile Include="Ps\ContainerStatus.cs" />
     <Compile Include="Ps\Docker.Aliases.Ps.cs" />
     <Compile Include="Ps\DockerPsResult.cs" />
@@ -63,12 +65,16 @@
     <Compile Include="GenericDockerRunner.cs" />
     <Compile Include="Build\Docker.Aliases.Build.cs" />
     <Compile Include="Build\DockerBuildSettings.cs" />
+    <Compile Include="Push\Docker.Aliases.Push.cs" />
+    <Compile Include="Push\DockerPushSettings.cs" />
     <Compile Include="Stop\Docker.Aliases.Stop.cs" />
     <Compile Include="Stop\DockerStopSettings.cs" />
     <Compile Include="Rmi\Docker.Aliases.Rmi.cs" />
     <Compile Include="Rmi\DockerRmiSettings.cs" />
     <Compile Include="Rm\DockerRmSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tag\Docker.Aliases.Tag.cs" />
+    <Compile Include="Tag\DockerTagSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Rm\Docker.Aliases.Rm.cs" />
@@ -77,7 +83,10 @@
   <ItemGroup>
     <Content Include="Build\args.txt" />
     <Content Include="Create\args.txt" />
+    <Content Include="Login\args.txt" />
     <Content Include="Ps\args.txt" />
+    <Content Include="Push\args.txt" />
+    <Content Include="Tag\args.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Cake.Docker/Cake.Docker.csproj
+++ b/src/Cake.Docker/Cake.Docker.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Create\Docker.Aliases.Create.cs" />
     <Compile Include="Create\DockerCreateSettings.cs" />
     <Compile Include="Cp\Docker.Aliases.Cp.cs" />
+    <Compile Include="DockerResolver.cs" />
     <Compile Include="Ps\ContainerStatus.cs" />
     <Compile Include="Ps\Docker.Aliases.Ps.cs" />
     <Compile Include="Ps\DockerPsResult.cs" />

--- a/src/Cake.Docker/DockerAliases.cs
+++ b/src/Cake.Docker/DockerAliases.cs
@@ -2,7 +2,7 @@
 
 namespace Cake.Docker
 {
-    [CakeAliasCategory("Container")]
+    [CakeAliasCategory("Docker")]
     public static partial class DockerAliases
     {
     }

--- a/src/Cake.Docker/DockerResolver.cs
+++ b/src/Cake.Docker/DockerResolver.cs
@@ -1,0 +1,64 @@
+﻿using Cake.Core;
+using Cake.Core.IO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cake.Docker
+{
+    internal static class DockerResolver
+    {
+        public static FilePath GetDockerPath(IFileSystem fileSystem, ICakeEnvironment environment)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+
+            if (environment == null)
+            {
+                throw new ArgumentNullException("environment");
+            }
+
+            // Cake already searches the PATH for the executable tool names.
+            // Check for other known locations.
+            return !environment.IsUnix() 
+                ? CheckCommonWindowsPaths(fileSystem)
+                : null;
+        }
+
+        /// <summary>
+        /// Check common docker client locations.
+        /// </summary>
+        /// <param name="fileSystem"></param>
+        /// <returns></returns>
+        private static FilePath CheckCommonWindowsPaths(IFileSystem fileSystem)
+        {
+            // The docker client is included as part of the Docker Toolbox installer 
+            // or can be installed using a Chocolatey package (name: docker).
+            // The Chocolatey install does not have a fixed location, but Docker Toolbox does.
+            return GetDefaultWindowsPaths(fileSystem)
+                .Select(path => path.CombineWithFilePath("docker.exe"))
+                .FirstOrDefault(dockerExecutable => fileSystem.GetFile(dockerExecutable).Exists);
+        }
+
+        /// <summary>
+        /// Get default paths for common docker client installations.
+        /// </summary>
+        /// <param name="fileSystem"></param>
+        /// <returns></returns>
+        private static DirectoryPath[] GetDefaultWindowsPaths(IFileSystem fileSystem)
+        {
+            var paths = new List<DirectoryPath>();
+
+            var programFiles = new DirectoryPath(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
+            var defaultDockerToolboxPath = programFiles.Combine("Docker Toolbox");
+            if (fileSystem.GetDirectory(defaultDockerToolboxPath).Exists)
+            {
+                paths.Add(defaultDockerToolboxPath);
+            }
+
+            return paths.ToArray();
+        }
+    }
+}

--- a/src/Cake.Docker/DockerTool.cs
+++ b/src/Cake.Docker/DockerTool.cs
@@ -2,6 +2,7 @@
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Cake.Docker
 {
@@ -12,6 +13,9 @@ namespace Cake.Docker
     public abstract class DockerTool<TSettings>: Tool<TSettings>
         where TSettings: ToolSettings
     {
+        private readonly ICakeEnvironment _environment;
+        private readonly IFileSystem _fileSystem;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DockerTool{TSettings}"/> class.
         /// </summary>
@@ -26,6 +30,8 @@ namespace Cake.Docker
             IGlobber globber)
             : base(fileSystem, environment, processRunner, globber)
         {
+            _fileSystem = fileSystem;
+            _environment = environment;
         }
 
         /// <summary>
@@ -43,7 +49,15 @@ namespace Cake.Docker
         /// <returns>The tool executable name.</returns>
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] { "docker.exe" };
+            return new[] { "docker.exe", "docker" };
+        }
+
+        protected override IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+        {
+            var path = DockerResolver.GetDockerPath(_fileSystem, _environment);
+            return path != null
+                ? new[] { path }
+                : Enumerable.Empty<FilePath>();
         }
     }
 }

--- a/src/Cake.Docker/Login/Docker.Aliases.Login.cs
+++ b/src/Cake.Docker/Login/Docker.Aliases.Login.cs
@@ -1,0 +1,57 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+
+namespace Cake.Docker
+{
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Register or log in to a Docker registry.
+        /// If no server is specified, the docker engine default is used.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="username"></param>
+        /// <param name="password"></param>
+        /// <param name="server"></param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Docker")]
+        public static void DockerLogin(this ICakeContext context, string username, string password, string server = null)
+        {
+            if (string.IsNullOrEmpty(username))
+            {
+                throw new ArgumentNullException("username");
+            }
+            if (string.IsNullOrEmpty(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            DockerLogin(context, new DockerLoginSettings {Username = username, Password = password, Email = "none"}, server);
+        }
+
+        /// <summary>
+        /// Register or log in to a Docker registry.
+        /// If no server is specified, the docker engine default is used.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="settings"></param>
+        /// <param name="server"></param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Docker")]
+        public static void DockerLogin(this ICakeContext context, DockerLoginSettings settings, string server = null)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            var runner = new GenericDockerRunner<DockerLoginSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            runner.Run("login", settings, server != null ? new[] { server } : null);
+        }
+    }
+}

--- a/src/Cake.Docker/Login/DockerLoginSettings.cs
+++ b/src/Cake.Docker/Login/DockerLoginSettings.cs
@@ -1,0 +1,21 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker login.
+    /// </summary>
+    public sealed class DockerLoginSettings : AutoToolSettings
+    {
+        /// <summary>
+        /// Email for login. Depreciated in Docker 1.11.0.
+        /// </summary>
+        public string Email { get; set; }
+        /// <summary>
+        /// Password for login.
+        /// </summary>
+        public string Password { get; set; }
+        /// <summary>
+        /// Username for login.
+        /// </summary>
+        public string Username { get; set; }
+    }
+}

--- a/src/Cake.Docker/Login/args.txt
+++ b/src/Cake.Docker/Login/args.txt
@@ -1,0 +1,7 @@
+﻿Register or log in to a Docker registry.
+If no server is specified, the default is defined by the daemon.
+
+  -e, --email        Email
+  --help             Print usage
+  -p, --password     Password
+  -u, --username     Username

--- a/src/Cake.Docker/Properties/AssemblyInfo.cs
+++ b/src/Cake.Docker/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0.0")]
-[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyVersion("0.4.0.0")]
+[assembly: AssemblyFileVersion("0.4.0.0")]

--- a/src/Cake.Docker/Push/Docker.Aliases.Push.cs
+++ b/src/Cake.Docker/Push/Docker.Aliases.Push.cs
@@ -1,0 +1,44 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+
+namespace Cake.Docker
+{
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Push an image or a repository to the registry.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="imageReference"></param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Docker")]
+        public static void DockerPush(this ICakeContext context, string imageReference)
+        {
+            DockerPush(context, new DockerPushSettings(), imageReference);
+        }
+
+        /// <summary>
+        /// Push an image or a repository to the registry with given <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="settings"></param>
+        /// <param name="imageReference"></param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Docker")]
+        public static void DockerPush(this ICakeContext context, DockerPushSettings settings, string imageReference)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (string.IsNullOrEmpty(imageReference))
+            {
+                throw new ArgumentNullException("imageReference");
+            }
+
+            var runner = new GenericDockerRunner<DockerPushSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            runner.Run("push", settings ?? new DockerPushSettings(), new [] { imageReference });
+        }
+    }
+}

--- a/src/Cake.Docker/Push/DockerPushSettings.cs
+++ b/src/Cake.Docker/Push/DockerPushSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker push.
+    /// </summary>
+    public sealed class DockerPushSettings : AutoToolSettings
+    {
+        /// <summary>
+        /// Skip image signing
+        /// </summary>
+        public bool DisableContentTrust { get; set; }
+    }
+}

--- a/src/Cake.Docker/Push/args.txt
+++ b/src/Cake.Docker/Push/args.txt
@@ -1,0 +1,2 @@
+﻿--disable-content-trust=true    Skip image signing
+--help                          Print usage

--- a/src/Cake.Docker/Rm/Docker.Aliases.Rm.cs
+++ b/src/Cake.Docker/Rm/Docker.Aliases.Rm.cs
@@ -26,7 +26,7 @@ namespace Cake.Docker
         /// <param name="containers"></param>
         [CakeMethodAlias]
         [CakeAliasCategory("Docker")]
-		public static void DockerRm(this ICakeContext context, DockerRmSettings settings, params string[] containers)
+        public static void DockerRm(this ICakeContext context, DockerRmSettings settings, params string[] containers)
         {
             if (context == null)
             {

--- a/src/Cake.Docker/Rmi/Docker.Aliases.Rmi.cs
+++ b/src/Cake.Docker/Rmi/Docker.Aliases.Rmi.cs
@@ -26,7 +26,7 @@ namespace Cake.Docker
         /// <param name="settings"></param>
         [CakeMethodAlias]
         [CakeAliasCategory("Docker")]
-		public static void DockerRmi(this ICakeContext context, DockerRmiSettings settings, params string[] images)
+        public static void DockerRmi(this ICakeContext context, DockerRmiSettings settings, params string[] images)
         {
             if (context == null)
             {

--- a/src/Cake.Docker/Tag/Docker.Aliases.Tag.cs
+++ b/src/Cake.Docker/Tag/Docker.Aliases.Tag.cs
@@ -1,0 +1,36 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+
+namespace Cake.Docker
+{
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Tag an image into a repository.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="imageReference"></param>
+        /// <param name="registryReference"></param>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Docker")]
+        public static void DockerTag(this ICakeContext context, string imageReference, string registryReference)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (string.IsNullOrEmpty(imageReference))
+            {
+                throw new ArgumentNullException("imageReference");
+            }
+            if (string.IsNullOrEmpty(registryReference))
+            {
+                throw new ArgumentNullException("registryReference");
+            }
+
+            var runner = new GenericDockerRunner<DockerTagSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Globber);
+            runner.Run("tag", new DockerTagSettings(), new[] { imageReference, registryReference });
+        }
+    }
+}

--- a/src/Cake.Docker/Tag/DockerTagSettings.cs
+++ b/src/Cake.Docker/Tag/DockerTagSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker tag.
+    /// </summary>
+    public sealed class DockerTagSettings : AutoToolSettings
+    {
+    }
+}

--- a/src/Cake.Docker/Tag/args.txt
+++ b/src/Cake.Docker/Tag/args.txt
@@ -1,0 +1,1 @@
+﻿--help             Print usage


### PR DESCRIPTION
- Added support for finding docker client on Unix
- Added support for finding Docker on Windows in the Docker Toolbox
  location (without requiring it to be on the path).
