### PR TITLE
Minor fix to line.indexof when building indexes

### DIFF
--- a/src/Cake.Docker/Ps/DockerPsParser.cs
+++ b/src/Cake.Docker/Ps/DockerPsParser.cs
@@ -52,7 +52,7 @@ namespace Cake.Docker
                 result.ImageIndex = line.IndexOf("IMAGE", StringComparison.Ordinal);
                 result.CommandIndex = line.IndexOf("COMMAND", result.ImageIndex, StringComparison.Ordinal);
                 result.CreatedIndex = line.IndexOf("CREATED", result.CommandIndex, StringComparison.Ordinal);
-                result.StatusIndex = line.IndexOf("STATUS", result.CommandIndex, StringComparison.Ordinal);
+                result.StatusIndex = line.IndexOf("STATUS", result.CreatedIndex, StringComparison.Ordinal);
                 result.PortsIndex = line.IndexOf("PORTS", result.StatusIndex, StringComparison.Ordinal);
                 result.NameIndex = line.IndexOf("NAMES", result.PortsIndex, StringComparison.Ordinal);
                 int sizeIndex = line.IndexOf("SIZE", result.PortsIndex, StringComparison.Ordinal);


### PR DESCRIPTION
Fixed very minor consistency bug. 

I'm was looking at the ps command with the idea of implementing the images command because I thought I needed the ID of the container I'm creating to save the tar. I'm now getting around that using the tag.

Do you think there is a requirement for the images command? 