### PR TITLE
Removes redundant partial attributes and summary comments

### DIFF
--- a/src/Cake.Docker/Build/Docker.Aliases.Build.cs
+++ b/src/Cake.Docker/Build/Docker.Aliases.Build.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with build command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with build command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Build/Docker.Aliases.ComposeBuild.cs
+++ b/src/Cake.Docker/Compose/Build/Docker.Aliases.ComposeBuild.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose build command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose build command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Create/Docker.Aliases.ComposeCreate.cs
+++ b/src/Cake.Docker/Compose/Create/Docker.Aliases.ComposeCreate.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose build command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose build command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Down/Docker.Aliases.ComposeDown.cs
+++ b/src/Cake.Docker/Compose/Down/Docker.Aliases.ComposeDown.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose down command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose down command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Kill/Docker.Aliases.ComposeKill.cs
+++ b/src/Cake.Docker/Compose/Kill/Docker.Aliases.ComposeKill.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose down command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose down command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Pause/Docker.Aliases.ComposePause.cs
+++ b/src/Cake.Docker/Compose/Pause/Docker.Aliases.ComposePause.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose pause command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose pause command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Pull/Docker.Aliases.ComposePull.cs
+++ b/src/Cake.Docker/Compose/Pull/Docker.Aliases.ComposePull.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose pull command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose pull command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Restart/Docker.Aliases.ComposeRestart.cs
+++ b/src/Cake.Docker/Compose/Restart/Docker.Aliases.ComposeRestart.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose restart command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose restart command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Rm/Docker.Aliases.ComposeRm.cs
+++ b/src/Cake.Docker/Compose/Rm/Docker.Aliases.ComposeRm.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose rm command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose rm command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Run/Docker.Aliases.ComposeRun.cs
+++ b/src/Cake.Docker/Compose/Run/Docker.Aliases.ComposeRun.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose run command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose run command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Scale/Docker.Aliases.ComposeScale.cs
+++ b/src/Cake.Docker/Compose/Scale/Docker.Aliases.ComposeScale.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose scale command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose scale command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Start/Docker.Aliases.ComposeStart.cs
+++ b/src/Cake.Docker/Compose/Start/Docker.Aliases.ComposeStart.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose start command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose start command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Stop/Docker.Aliases.ComposeStop.cs
+++ b/src/Cake.Docker/Compose/Stop/Docker.Aliases.ComposeStop.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose stop command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose stop command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Unpause/Docker.Aliases.ComposeUnpause.cs
+++ b/src/Cake.Docker/Compose/Unpause/Docker.Aliases.ComposeUnpause.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose unpause command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose unpause command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Compose/Up/Docker.Aliases.ComposeUp.cs
+++ b/src/Cake.Docker/Compose/Up/Docker.Aliases.ComposeUp.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with docker-compose up command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with docker-compose up command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Cp/Docker.Aliases.Cp.cs
+++ b/src/Cake.Docker/Cp/Docker.Aliases.Cp.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with cp command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with cp command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Create/Docker.Aliases.Create.cs
+++ b/src/Cake.Docker/Create/Docker.Aliases.Create.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with create command.
-    /// </summary>
-    [CakeAliasCategory("Docker")] 
+    // Contains functionality for working with create command.
     partial class DockerAliases
     {
 
@@ -34,7 +31,6 @@ namespace Cake.Docker
         /// <param name="args">The arguments.</param>
         /// <param name="command">The command.</param>
         [CakeMethodAlias]
-        [CakeAliasCategory("Docker")]
         public static void DockerCreate(this ICakeContext context, DockerCreateSettings settings, string image, string command, params string[] args)
         {
             if (context == null)

--- a/src/Cake.Docker/DockerAliases.cs
+++ b/src/Cake.Docker/DockerAliases.cs
@@ -1,7 +1,10 @@
 ﻿using Cake.Core.Annotations;
 
 namespace Cake.Docker
-{
+{    
+    /// <summary>
+    /// Contains functionality for working with Docker commands.
+    /// </summary>
     [CakeAliasCategory("Docker")]
     public static partial class DockerAliases
     {

--- a/src/Cake.Docker/Load/Docker.Aliases.Load.cs
+++ b/src/Cake.Docker/Load/Docker.Aliases.Load.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with load command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with load command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Login/Docker.Aliases.Login.cs
+++ b/src/Cake.Docker/Login/Docker.Aliases.Login.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with login command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with login command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Network/Connect/Docker.Aliases.NetworkConnect.cs
+++ b/src/Cake.Docker/Network/Connect/Docker.Aliases.NetworkConnect.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with network connect command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with network connect command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Network/Create/Docker.Aliases.NetworkCreate.cs
+++ b/src/Cake.Docker/Network/Create/Docker.Aliases.NetworkCreate.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with network create command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with network create command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Network/Disconnect/Docker.Aliases.NetworkDisconnect.cs
+++ b/src/Cake.Docker/Network/Disconnect/Docker.Aliases.NetworkDisconnect.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with network disconnect command.
-    /// </summary>
-    [CakeAliasCategory("Docker")] 
+    // Contains functionality for working with network disconnect command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Network/Remove/Docker.Aliases.NetworkRemove.cs
+++ b/src/Cake.Docker/Network/Remove/Docker.Aliases.NetworkRemove.cs
@@ -6,10 +6,7 @@ using System.Linq;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with network remove command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with network remove command.
     partial class DockerAliases
     {
         /// <summary>
@@ -30,7 +27,6 @@ namespace Cake.Docker
         /// <param name="network">The network.</param>
         /// <param name="args">The arguments.</param>
         [CakeMethodAlias]
-        [CakeAliasCategory("Docker")]
         public static void DockerNetworkRemove(this ICakeContext context, string[] network, params string[] args)
         {
             if (context == null)

--- a/src/Cake.Docker/Ps/Docker.Aliases.Ps.cs
+++ b/src/Cake.Docker/Ps/Docker.Aliases.Ps.cs
@@ -6,10 +6,7 @@ using System.Linq;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with ps command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with ps command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Pull/Docker.Aliases.Push.cs
+++ b/src/Cake.Docker/Pull/Docker.Aliases.Push.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with push command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with push command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Push/Docker.Aliases.Pull.cs
+++ b/src/Cake.Docker/Push/Docker.Aliases.Pull.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with push command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with push command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Rm/Docker.Aliases.Rm.cs
+++ b/src/Cake.Docker/Rm/Docker.Aliases.Rm.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with rm command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with rm command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Rmi/Docker.Aliases.Rmi.cs
+++ b/src/Cake.Docker/Rmi/Docker.Aliases.Rmi.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with rmi command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with rmi command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Run/Docker.Aliases.Run.cs
+++ b/src/Cake.Docker/Run/Docker.Aliases.Run.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with run command.
-    /// </summary>
-    [CakeAliasCategory("Docker")] 
+    // Contains functionality for working with run command.
     partial class DockerAliases
     {
 
@@ -34,7 +31,6 @@ namespace Cake.Docker
         /// <param name="args">The arguments.</param>
         /// <param name="command">The command.</param>
         [CakeMethodAlias]
-        [CakeAliasCategory("Docker")]
         public static void DockerRun(this ICakeContext context, DockerRunSettings settings, string image, string command, params string[] args)
         {
             if (context == null)

--- a/src/Cake.Docker/Save/Docker.Aliases.Save.cs
+++ b/src/Cake.Docker/Save/Docker.Aliases.Save.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with save command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with save command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Stop/Docker.Aliases.Stop.cs
+++ b/src/Cake.Docker/Stop/Docker.Aliases.Stop.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with stop command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with stop command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Swarm/Init/Docker.Aliases.SwarmInit.cs
+++ b/src/Cake.Docker/Swarm/Init/Docker.Aliases.SwarmInit.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with swarm init command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with swarm init command.
     partial class DockerAliases
     {
 

--- a/src/Cake.Docker/Swarm/Join/Docker.Aliases.SwarmJoin.cs
+++ b/src/Cake.Docker/Swarm/Join/Docker.Aliases.SwarmJoin.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with swarm join command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with swarm join command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Swarm/Leave/Docker.Aliases.SwarmLeave.cs
+++ b/src/Cake.Docker/Swarm/Leave/Docker.Aliases.SwarmLeave.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with swarm leave command.
-    /// </summary>
-    [CakeAliasCategory("Docker")] 
+    // Contains functionality for working with swarm leave command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Swarm/Update/Docker.Aliases.SwarmUpdate.cs
+++ b/src/Cake.Docker/Swarm/Update/Docker.Aliases.SwarmUpdate.cs
@@ -5,10 +5,7 @@ using System.Collections.Generic;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with swarm update command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with swarm update command.
     partial class DockerAliases
     {
         /// <summary>

--- a/src/Cake.Docker/Tag/Docker.Aliases.Tag.cs
+++ b/src/Cake.Docker/Tag/Docker.Aliases.Tag.cs
@@ -4,10 +4,7 @@ using System;
 
 namespace Cake.Docker
 {
-    /// <summary>
-    /// Contains functionality for working with tag command.
-    /// </summary>
-    [CakeAliasCategory("Docker")]
+    // Contains functionality for working with tag command.
     partial class DockerAliases
     {
         /// <summary>


### PR DESCRIPTION
I removed the `CakeAliasCategory` attribute and `<summary>` comments from all but the "main" partial for `DockerAliases`. This was causing some documentation redundancy here: http://cakebuild.net/dsl/docker/

There were actually two different but related parts to this...

## Summary Comments

Since partial classes are actually all defining the same underlying class, any XML comments applied to one of the partials are actually applied to all of them. Both the Cake docs generator (Wyam) as well as Intellisense tools will aggregate all the XML doc comments on partial definitions since it's never clear which one is the "right" one. For example, see this screen shot from VS Code:

![2017-05-08_12h41_54](https://cloud.githubusercontent.com/assets/1020407/25815649/6db271bc-33ef-11e7-99e1-c82d7713e18c.png)

In this case, the summary for each partial class definition were combining into a huge aggregate summary in the Cake docs.

## Attributes

Since each partial definition is actually defining the same class, any attributes applied to partial classes are applied in aggregate to the actual final class. In other words, if you have 3 partial class definitions, each with the same attribute applied to them, it's equivalent to having a single non-partial class definition with the same attribute applied three times.

The Cake docs generator was seeing each of the `CakeAliasCategory` attributes from each of the partial class definitions and treating them as distinct classes even though it was all the same class. I've created an issue at the Cake website repo to add a guard for this case (https://github.com/cake-build/website/issues/356), but the `CakeAliasCategory` is really only needed once.