### PR TITLE
Add more docker commands

### DIFF
--- a/src/Cake.Docker/Cp/DockerCpSettings.cs
+++ b/src/Cake.Docker/Cp/DockerCpSettings.cs
@@ -1,7 +1,7 @@
 ﻿namespace Cake.Docker
 {
     /// <summary>
-    /// Settings for docker build.
+    /// Settings for docker cp command.
     /// </summary>
     public sealed class DockerCpSettings: AutoToolSettings
     {

--- a/src/Cake.Docker/Exec/Docker.Aliases.Exec.cs
+++ b/src/Cake.Docker/Exec/Docker.Aliases.Exec.cs
@@ -1,0 +1,98 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Cake.Docker
+{
+    // Contains functionality for working with exec command.
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Copy files from/to using default settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="command"></param>
+        /// <param name="container">exec a command inside the container</param>
+        /// <param name="env">Set environment variables</param>
+        /// <param name="interactive">Keep STDIN open even if not attached</param>
+        /// <param name="privileged">Give extended privileges to the command</param>
+        /// <param name="tty">Allocate a pseudo-TTY</param>
+        /// <param name="user">Username or UID (format: name or uid : group or gid ])</param>
+        [CakeMethodAlias]
+        public static void DockerExec(this ICakeContext context,
+                                      string command,
+                                      string container,
+                                      string env = "",
+                                      bool interactive = false,
+                                      bool privileged = false,
+                                      bool tty = false,
+                                      string user = "")
+        {
+            DockerExec(context, command, container, new DockerExecSettings(), env, interactive, privileged, tty, user);
+        }
+        /// <summary>
+        /// Copy files from/to container given <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="command"></param>
+        /// <param name="container"></param>
+        /// <param name="env">Set environment variables</param>
+        /// <param name="interactive">Keep STDIN open even if not attached</param>
+        /// <param name="privileged">Give extended privileges to the command</param>
+        /// <param name="tty">Allocate a pseudo-TTY</param>
+        /// <param name="user">Username or UID (format: name or uid : group or gid ])</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void DockerExec(this ICakeContext context,
+                                      string command,
+                                      string container,
+                                      DockerExecSettings settings,
+                                      string env = "",
+                                      bool interactive = false,
+                                      bool privileged = false,
+                                      bool tty = false,
+                                      string user = "")
+        {
+            string exec = "exec";
+
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (string.IsNullOrEmpty(command))
+            {
+                throw new ArgumentNullException("command");
+            }
+            if (string.IsNullOrWhiteSpace(container))
+            {
+                throw new ArgumentNullException("container");
+            }
+
+            if (interactive)
+            {
+                exec = "exec -i";
+            }
+            if (privileged)
+            {
+                exec += " --privileged";
+            }
+            if (tty)
+            {
+                exec += " -t";
+            }
+            if (string.IsNullOrWhiteSpace(env))
+            {
+                exec += " -e " + env;
+            }
+            if (string.IsNullOrWhiteSpace(user))
+            {
+                exec += " -u " + user;
+            }
+
+            var runner = new GenericDockerRunner<DockerExecSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(exec, settings ?? new DockerExecSettings(), new string[] { container, command });
+        }
+
+    }
+}

--- a/src/Cake.Docker/Exec/DockerExecSettings.cs
+++ b/src/Cake.Docker/Exec/DockerExecSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker exec command.
+    /// </summary>
+    public sealed class DockerExecSettings: AutoToolSettings
+    {
+        /// <summary>
+        /// Always follow symbol link in SRC_PATH
+        /// </summary>
+        public bool FollowLink { get; set; }
+    }
+}

--- a/src/Cake.Docker/Logs/Docker.Aliases.Logs.cs
+++ b/src/Cake.Docker/Logs/Docker.Aliases.Logs.cs
@@ -1,0 +1,43 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+
+namespace Cake.Docker
+{
+    // Contains functionality for working with logs command.
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Stops an array of <paramref name="containers"/> using default settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="containers">The list of containers.</param>
+        [CakeMethodAlias]
+        public static void DockerLogs(this ICakeContext context, params string[] containers)
+        {
+            DockerLogs(context, new DockerLogsSettings(), containers);
+        }
+        
+        /// <summary>
+        /// Stops an array of <paramref name="containers"/> using the give <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="containers">The list of containers.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+		public static void DockerLogs(this ICakeContext context, DockerLogsSettings settings, params string[] containers)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (containers == null || containers.Length == 0)
+            {
+                throw new ArgumentNullException("containers");
+            }
+
+            var runner = new GenericDockerRunner<DockerLogsSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run("logs", settings ?? new DockerLogsSettings(), containers);
+        }
+    }
+}

--- a/src/Cake.Docker/Logs/DockerLogsSettings.cs
+++ b/src/Cake.Docker/Logs/DockerLogsSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    ///  Settings for docker Logs
+    /// </summary>
+    public sealed class DockerLogsSettings: AutoToolSettings
+    {
+        /// <summary>
+        ///  Seconds to wait for stop before killing it.
+        /// </summary>
+        public int? Time { get; set; }
+    }
+}

--- a/src/Cake.Docker/Start/Docker.Aliases.Start.cs
+++ b/src/Cake.Docker/Start/Docker.Aliases.Start.cs
@@ -1,0 +1,43 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+
+namespace Cake.Docker
+{
+    // Contains functionality for working with start command.
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Stops an array of <paramref name="containers"/> using default settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="containers">The list of containers.</param>
+        [CakeMethodAlias]
+        public static void DockerStart(this ICakeContext context, params string[] containers)
+        {
+            DockerStart(context, new DockerStartSettings(), containers);
+        }
+        
+        /// <summary>
+        /// Stops an array of <paramref name="containers"/> using the give <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="containers">The list of containers.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+		public static void DockerStart(this ICakeContext context, DockerStartSettings settings, params string[] containers)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (containers == null || containers.Length == 0)
+            {
+                throw new ArgumentNullException("containers");
+            }
+
+            var runner = new GenericDockerRunner<DockerStartSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run("start", settings ?? new DockerStartSettings(), containers);
+        }
+    }
+}

--- a/src/Cake.Docker/Start/DockerStartSettings.cs
+++ b/src/Cake.Docker/Start/DockerStartSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    ///  Settings for docker Start
+    /// </summary>
+    public sealed class DockerStartSettings: AutoToolSettings
+    {
+        /// <summary>
+        ///  Seconds to wait for stop before killing it.
+        /// </summary>
+        public int? Time { get; set; }
+    }
+}


### PR DESCRIPTION
Hi Guys (@MihaMarkic), I actually loved the Cake.Docker extension and decide start to use in my job. Actually I am trying to use it to help me on my integration test automation and this pull request help to what I need to accomplish it. 

this is a simple example of how I've been used:
``` csharp
#r "C:\git\Cake.Docker\src\Cake.Docker\bin\Debug\net45\Cake.Docker.dll"

var target = Argument("target", "Default");

Task("DockerStop").Does(() => {
    DockerStop("b56c70a1d2b1");
});

Task("DockerStart").IsDependentOn("DockerStop").Does(() => {
    DockerStart("b56c70a1d2b1");
});

Task("DockerExec").IsDependentOn("DockerStart").Does(() => {
    DockerExec("mysql --help", "b56c70a1d2b1", interactive:true);
});

Task("DockerLogs").IsDependentOn("DockerExec").Does(() => {
    DockerLogs("b56c70a1d2b1");
});

Task("Default").IsDependentOn("DockerLogs");

RunTarget(target); 
```