### PR TITLE
cake: Update framework version to 0.22.2

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,5 @@
+# Cake.Docker 1.0.0
+- Support Cake 0.22.2 which is a breaking change
 # Cake.Docker 0.7.7
 - .NET Core support
 # Cake.Docker 0.7.6

--- a/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
+++ b/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.Docker.Tests</RootNamespace>
     <AssemblyName>Cake.Docker.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.22.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.22.2\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/src/Cake.Docker.Tests/packages.config
+++ b/src/Cake.Docker.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.22.2" targetFramework="net462" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/src/Cake.Docker.nuspec
+++ b/src/Cake.Docker.nuspec
@@ -22,7 +22,9 @@
    </metadata>
 
    <files>
-		<file src="Cake.Docker\bin\Release\Cake.Docker.dll" target="lib\net45\Cake.Docker.dll" />
-        <file src="Cake.Docker\bin\Release\Cake.Docker.XML" target="lib\net45\Cake.Docker.XML" />
+        <file src="Cake.Docker\bin\Release\net46\Cake.Docker.dll" target="lib\net46\Cake.Docker.dll" />
+        <file src="Cake.Docker\bin\Release\net46\Cake.Docker.XML" target="lib\net46\Cake.Docker.XML" />
+        <file src="Cake.Docker\bin\Release\netstandard1.6\Cake.Docker.dll" target="lib\netstandard1.6\Cake.Docker.dll" />
+        <file src="Cake.Docker\bin\Release\netstandard1.6\Cake.Docker.XML" target="lib\netstandard1.6\Cake.Docker.XML" />
    </files>
 </package>

--- a/src/Cake.Docker/Cake.Docker.csproj
+++ b/src/Cake.Docker/Cake.Docker.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
     <AssemblyName>Cake.Docker</AssemblyName>
     <RootNamespace>Cake.Docker</RootNamespace>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
@@ -22,15 +21,15 @@
     <IncludeSymbols>true</IncludeSymbols>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageReleaseNotes>See https://github.com/MihaMarkic/Cake.Docker/blob/master/ReleaseNotes.md</PackageReleaseNotes>
-    <Version>0.7.7</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>bin\Debug\net45\Cake.Docker.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net46\Cake.Docker.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.17.0">
+    <PackageReference Include="Cake.Core" Version="0.22.2">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/build.cake
+++ b/src/build.cake
@@ -1,4 +1,5 @@
-﻿#addin "Cake.FileHelpers"
+﻿#addin Cake.FileHelpers
+#tool NUnit.ConsoleRunner
 
 var Project = Directory("./Cake.Docker/");
 var TestProject = Directory("./Cake.Docker.Tests/");


### PR DESCRIPTION
This commit will upgrade the dependencies to the latest cake framework
dlls. Furthermore, the nuget will provide a set of `net46` dlls and a set
of `netstandard1.6` dlls.

Since this is a breaking change, bump the version to 1.0.0.