### PR TITLE
At some point the booleans were change to nullable booleans

### DIFF
--- a/src/Cake.Docker.Tests/ArgumentsBuilderExtensionTest.cs
+++ b/src/Cake.Docker.Tests/ArgumentsBuilderExtensionTest.cs
@@ -177,11 +177,19 @@ namespace Cake.Docker.Tests
         public class GetArgumentFromNullableBoolProperty
         {
             [Test]
-            public void WhenGivenValue_FormatsProperly()
+            public void WhenGivenValueIsTrue_FormatsProperly()
             {
                 var actual = ArgumentsBuilderExtension.GetArgumentFromNullableBoolProperty(NullableBoolProperty, true);
 
                 Assert.That(actual, Is.EqualTo("--nullable-bool"));
+            }
+
+            [Test]
+            public void WhenGivenValueIsFalse_NullIsReturned()
+            {
+                var actual = ArgumentsBuilderExtension.GetArgumentFromNullableBoolProperty(NullableBoolProperty, false);
+
+                Assert.That(actual, Is.Null);
             }
 
             [Test]

--- a/src/Cake.Docker.Tests/Build/Docker.Aliases.BuildTest.cs
+++ b/src/Cake.Docker.Tests/Build/Docker.Aliases.BuildTest.cs
@@ -31,5 +31,61 @@ namespace Cake.Docker.Tests.Build
 
             Assert.That(actual.Args, Is.EqualTo("build --rm path"));
         }
+
+        [Test]
+        public void WhenRmFlagIsSetToFalse_CommandLineDoesNotHaveRm()
+        {
+            var fixture = new DockerBuildFixture
+            {
+                Settings = new DockerImageBuildSettings { Rm = false },
+                Path = "path"
+            };
+
+            var actual = fixture.Run();
+
+            Assert.That(actual.Args, Is.EqualTo("build path"));
+        }
+
+        [Test]
+        public void WhenForceRmFlagIsSetToFalse_CommandLineDoesNotHaveForceRm()
+        {
+            var fixture = new DockerBuildFixture
+            {
+                Settings = new DockerImageBuildSettings { ForceRm = false },
+                Path = "path"
+            };
+
+            var actual = fixture.Run();
+
+            Assert.That(actual.Args, Is.EqualTo("build path"));
+        }
+
+        [Test]
+        public void WhenPullFlagIsSetToFalse_CommandLineDoesNotHavePull()
+        {
+            var fixture = new DockerBuildFixture
+            {
+                Settings = new DockerImageBuildSettings { Pull = false },
+                Path = "path"
+            };
+
+            var actual = fixture.Run();
+
+            Assert.That(actual.Args, Is.EqualTo("build path"));
+        }
+
+        [Test]
+        public void WhenPullFlagIsSetToTrue_CommandLineDoesHavePull()
+        {
+            var fixture = new DockerBuildFixture
+            {
+                Settings = new DockerImageBuildSettings { Pull = true },
+                Path = "path"
+            };
+
+            var actual = fixture.Run();
+
+            Assert.That(actual.Args, Is.EqualTo("build --pull path"));
+        }
     }
 }

--- a/src/Cake.Docker/ArgumentsBuilderExtension.cs
+++ b/src/Cake.Docker/ArgumentsBuilderExtension.cs
@@ -233,7 +233,11 @@ namespace Cake.Docker
         /// <returns></returns>
         public static string GetArgumentFromNullableBoolProperty(PropertyInfo property, bool? value)
         {
-            return value.HasValue ? $"--{GetPropertyName(property.Name)}" : null;
+            if (value ?? false)
+            {
+                return $"--{GetPropertyName(property.Name)}";
+            }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
which introduced the odd side effect that if you were being explicit in your cake scripts and setting  "Pull = false" it would add the --pull argument.

Not sure what the value in moving from booleans that had a default value of false to a nullable boolean was, but it was the parser changes introduced for this that caused the issue.