### PR TITLE
Add custom command functionality

### DIFF
--- a/src/Cake.Docker/Custom/CustomCommand/Docker.Aliases.CustomCommand.cs
+++ b/src/Cake.Docker/Custom/CustomCommand/Docker.Aliases.CustomCommand.cs
@@ -1,0 +1,66 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Cake.Docker
+{
+    // Contains functionality for running any custom command which are not yet implemented.
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Run a custom docker command
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="command">The custom command.</param>
+        [CakeMethodAlias]
+        public static IEnumerable<string> DockerCustomCommand(this ICakeContext context, string command)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            return DockerCustomCommand(context, new DockerCustomCommandSettings(), command);
+        }
+
+        /// <summary>
+        /// Run a custom docker command
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="command">The custom command.</param>
+        [CakeMethodAlias]
+        public static IEnumerable<string> DockerCustomCommand(this ICakeContext context, DockerCustomCommandSettings settings, string command)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrEmpty(command))
+            {
+                throw new ArgumentNullException("command");
+            }
+
+
+            var runner = new GenericDockerRunner<DockerCustomCommandSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+
+            string commandName = command;
+            string commandArguments = "";
+
+            var space = command.IndexOf(" ");
+            if (space > -1)
+            {
+                commandName = command.Substring(0, space);
+                commandArguments = command.Substring(space);
+            }
+
+            return runner.RunWithResult(commandName, settings, r => r.ToArray(), new[] { commandArguments });
+        }
+    }
+}

--- a/src/Cake.Docker/Custom/CustomCommand/DockerCustomCommandSettings.cs
+++ b/src/Cake.Docker/Custom/CustomCommand/DockerCustomCommandSettings.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Cake.Docker
+{
+	/// <summary>
+	/// Settings for docker login [OPTIONS] [SERVER].
+	/// Log in to a Docker registry
+	/// </summary>
+	public sealed class DockerCustomCommandSettings : AutoToolSettings
+	{
+	}
+}


### PR DESCRIPTION
Add functionality to call docker commands not yet supported by this library. 
You can pass a string as a docker command so you can run any command with this. Useful as a workaround for missing commands (images, image/network/volume prune, ...)