### PR TITLE
Docker logout and login bugfix

### DIFF
--- a/src/Cake.Docker/Registry/Login/Docker.Aliases.Login.cs
+++ b/src/Cake.Docker/Registry/Login/Docker.Aliases.Login.cs
@@ -50,7 +50,7 @@ namespace Cake.Docker
             }
 
             var runner = new GenericDockerRunner<DockerRegistryLoginSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run("login", settings, server != null ? new[] { server } : null);
+            runner.Run("login", settings, server != null ? new[] { server } : new string[] { });
         }
     }
 }

--- a/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
+++ b/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
@@ -17,7 +17,7 @@ namespace Cake.Docker
         public static void DockerLogout(this ICakeContext context, string server = null)
         {
             var runner = new GenericDockerRunner<DockerRegistryLogoutSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run("logout", new DockerRegistryLogoutSettings(), server != null ? new[] { server } : null);
+            runner.Run("logout", new DockerRegistryLogoutSettings(), server != null ? new[] { server } : new string[]{ });
         }
     }
 }

--- a/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
+++ b/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
@@ -16,8 +16,30 @@ namespace Cake.Docker
         [CakeMethodAlias]
         public static void DockerLogout(this ICakeContext context, string server = null)
         {
+            DockerLogout(context, new DockerRegistryLogoutSettings(), server);
+        }
+
+        /// <summary>
+        /// Logout from a Docker registry.
+        /// If no server is specified, the docker engine default is used.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="server">The server.</param>
+        [CakeMethodAlias]
+        public static void DockerLogout(this ICakeContext context, DockerRegistryLogoutSettings settings, string server = null)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
             var runner = new GenericDockerRunner<DockerRegistryLogoutSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run("logout", new DockerRegistryLogoutSettings(), server != null ? new[] { server } : new string[]{ });
+            runner.Run("logout", settings, server != null ? new[] { server } : new string[]{ });
         }
     }
 }

--- a/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
+++ b/src/Cake.Docker/Registry/Logout/Docker.Aliases.Logout.cs
@@ -16,8 +16,8 @@ namespace Cake.Docker
         [CakeMethodAlias]
         public static void DockerLogout(this ICakeContext context, string server = null)
         {
-            var runner = new GenericDockerRunner<DockerRegistryLoginSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run("logout", null, server != null ? new[] { server } : null);
+            var runner = new GenericDockerRunner<DockerRegistryLogoutSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run("logout", new DockerRegistryLogoutSettings(), server != null ? new[] { server } : null);
         }
     }
 }

--- a/src/Cake.Docker/Registry/Logout/DockerRegistryLogoutSettings.cs
+++ b/src/Cake.Docker/Registry/Logout/DockerRegistryLogoutSettings.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker logout [SERVER].
+    /// Logout from a Docker registry
+    /// </summary>
+    public sealed class DockerRegistryLogoutSettings : AutoToolSettings
+    {
+    }
+}


### PR DESCRIPTION
Hi @MihaMarkic 
there was a bug in the registry logout. I passed `null` as a `settings` which is asserted in the `GenericDockerRunner` so i created an empty settings class and add an new overload to DockerLogout.

I also find a bug which is present in the `DockerLogin` and `DockerLogout` functionality. The `GenericDockerRunner` also check if `additional` parameter is null. If no server was specified to login/logout it passes a null in `additional` parameter. It should be an empty list. I tested this fix and i can login/logout to the docker.io after the fix.