### PR TITLE
Fix log command and return log lines

### DIFF
--- a/src/Cake.Docker/Container/Logs/Docker.Aliases.Logs.cs
+++ b/src/Cake.Docker/Container/Logs/Docker.Aliases.Logs.cs
@@ -1,6 +1,8 @@
 ﻿using Cake.Core;
 using Cake.Core.Annotations;
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Cake.Docker
 {
@@ -12,9 +14,9 @@ namespace Cake.Docker
         /// <param name="context">The context.</param>
         /// <param name="container">The list of containers.</param>
         [CakeMethodAlias]
-        public static void DockerLogs(this ICakeContext context, string container)
+        public static IEnumerable<string> DockerLogs(this ICakeContext context, string container)
         {
-            DockerLogs(context, new DockerContainerLogsSettings(), container);
+            return DockerLogs(context, new DockerContainerLogsSettings(), container);
         }
         
         /// <summary>
@@ -24,7 +26,7 @@ namespace Cake.Docker
         /// <param name="container">The list of containers.</param>
         /// <param name="settings">The settings.</param>
         [CakeMethodAlias]
-		public static void DockerLogs(this ICakeContext context, DockerContainerLogsSettings settings, string container)
+		public static IEnumerable<string> DockerLogs(this ICakeContext context, DockerContainerLogsSettings settings, string container)
         {
             if (context == null)
             {
@@ -35,7 +37,7 @@ namespace Cake.Docker
                 throw new ArgumentNullException("container");
             }
             var runner = new GenericDockerRunner<DockerContainerLogsSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Run("start", settings ?? new DockerContainerLogsSettings(), new string[] { container });
+            return runner.RunWithResult("logs", settings ?? new DockerContainerLogsSettings(), r => r.ToArray(), new string[] { container });
         }
     }
 }


### PR DESCRIPTION
- Fix the command (`start` -> `logs`)
- Return the command result as string enumerable