### PR TITLE
#29 - Bumped Cake dependencies to latest

### DIFF
--- a/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
+++ b/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
@@ -1,20 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Cake" Version="0.22.0" />
-    <PackageReference Include="Cake.Testing" Version="0.22.0" />
+    <PackageReference Include="Cake" Version="0.26.1" />
+    <PackageReference Include="Cake.Testing" Version="0.26.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Cake.Docker\Cake.Docker.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Cake.Docker/Cake.Docker.csproj
+++ b/src/Cake.Docker/Cake.Docker.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Cake.Docker</AssemblyName>
     <RootNamespace>Cake.Docker</RootNamespace>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
@@ -9,7 +8,6 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
-
   <PropertyGroup>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>Cake.Docker</PackageId>
@@ -23,26 +21,20 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageReleaseNotes>See https://github.com/MihaMarkic/Cake.Docker/blob/master/ReleaseNotes.md</PackageReleaseNotes>
     <Version>0.8.5</Version>
-	 <PackageIconUrl>https://raw.githubusercontent.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
   </PropertyGroup>
-
   <PropertyGroup>
     <DocumentationFile>bin\Debug\net46\Cake.Docker.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Ps\**" />
     <EmbeddedResource Remove="Ps\**" />
     <None Remove="Ps\**" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Registry\Logout\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Also switched from netstandard1.6 to netstandard2.0 as required by newer versions of Cake.