### PR TITLE
Add platform switch to docker run, image, create commands

### DIFF
--- a/src/Cake.Docker.Tests/Build/DockerContainerRunTest.cs
+++ b/src/Cake.Docker.Tests/Build/DockerContainerRunTest.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.Framework;
+
+namespace Cake.Docker.Tests.Build
+{
+    [TestFixture]
+    public class DockerContainerRunTest
+    {
+        [Test]
+        public void WhenPlatformIsSet_CommandLineIsCorrect()
+        {
+            // TODO write docker run test
+        }
+    }
+}

--- a/src/Cake.Docker/Container/Run/DockerContainerRunSettings.cs
+++ b/src/Cake.Docker/Container/Run/DockerContainerRunSettings.cs
@@ -388,6 +388,12 @@ namespace Cake.Docker
 		/// Tune container pids limit (set -1 for unlimited)
 		/// </summary>
 		public Int64? PidsLimit { get; set; }
+	    /// <summary>
+	    /// --platform
+	    /// default: 
+	    /// Set platform if server is multi-platform capable
+	    /// </summary>
+	    public string Platform { get; set; }
 		/// <summary>
 		/// --privileged
 		/// default: false

--- a/src/Cake.Docker/Container/Run/args.txt
+++ b/src/Cake.Docker/Container/Run/args.txt
@@ -72,6 +72,7 @@
 --oom-score-adj 	0 	Tune host’s OOM preferences (-1000 to 1000)
 --pid 	  	PID namespace to use
 --pids-limit 	0 	Tune container pids limit (set -1 for unlimited)
+--platform 	string	Set platform if server is multi-platform capable
 --privileged 	false 	Give extended privileges to this container
 --publish, -p 	  	Publish a container’s port(s) to the host
 --publish-all, -P 	false 	Publish all exposed ports to random ports
@@ -96,3 +97,4 @@
 --volume-driver 	  	Optional volume driver for the container
 --volumes-from 	  	Mount volumes from the specified container(s)
 --workdir, -w 	  	Working directory inside the container
+


### PR DESCRIPTION
Adding [platform switch](https://github.com/moby/moby/pull/34642) to `docker run|image|create`. 

- [ ] docker run - *started*
- [ ] docker image
- [ ] docker create

Creating this PR as a place holder for a conversation about adding support for the `platform` tag. I took a stab at what it would take for `docker run` support. I am concerned I am not doing this correctly. Looking at `SettingsGenerator.sln` It appears you have some infrastructure for converting the command line usage output to settings objects? Should I be taking that route vs manually adding this?