### PR TITLE
Add support for docker-compose exec

### DIFF
--- a/src/Cake.Docker/Compose/Exec/Docker.Aliases.ComposeExec.cs
+++ b/src/Cake.Docker/Compose/Exec/Docker.Aliases.ComposeExec.cs
@@ -1,0 +1,60 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Cake.Docker
+{
+    // Contains functionality for working with docker-compose exec command.
+    partial class DockerAliases
+    {
+        /// <summary>
+        /// Runs docker-compose exec with default settings.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="service">The service.</param>
+        /// <param name="command">The command.</param>
+        /// <param name="args">The arguments.</param>
+        [CakeMethodAlias]
+        public static void DockerComposeExec(this ICakeContext context, string service, string command, params string[] args)
+        {
+            DockerComposeExec(context, new DockerComposeExecSettings(), service, command, args);
+        }
+
+        /// <summary>
+        /// Runs docker-compose exec given <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="service">The service.</param>
+        /// <param name="command">The command.</param>
+        /// <param name="args">The arguments.</param>
+        /// <param name="settings">The settings.</param>
+        [CakeMethodAlias]
+        public static void DockerComposeExec(this ICakeContext context, DockerComposeExecSettings settings, string service, string command, params string[] args)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (string.IsNullOrEmpty(service))
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+            if (string.IsNullOrEmpty(command))
+            {
+                throw new ArgumentNullException(nameof(command));
+            }
+
+            var runner = new GenericDockerComposeRunner<DockerComposeExecSettings>(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+
+            var arguments = new List<string> { service, command };
+
+            if (args.Length > 0)
+            {
+                arguments.AddRange(args);
+            }
+
+            runner.Run("exec", settings ?? new DockerComposeExecSettings(), arguments.ToArray());
+        }
+    }
+}

--- a/src/Cake.Docker/Compose/Exec/DockerComposeExecSettings.cs
+++ b/src/Cake.Docker/Compose/Exec/DockerComposeExecSettings.cs
@@ -1,0 +1,49 @@
+﻿namespace Cake.Docker
+{
+    /// <summary>
+    /// Settings for docker-compose exec [options] [-e KEY=VAL...] SERVICE COMMAND [ARGS...]
+    /// </summary>
+    public sealed class DockerComposeExecSettings : DockerComposeSettings
+    {
+        /// <summary>
+        /// -d, --detach
+        /// Detached mode: Run command in the background.
+        /// </summary>
+        public bool? Detach { get; set; }
+
+        /// <summary>
+        /// --privileged
+        /// Give extended privileges to the process.
+        /// </summary>
+        public bool? Privileged { get; set; }
+
+        /// <summary>
+        /// -u, --user USER
+        /// Run the command as this user.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// --index=index
+        /// index of the container if there are multiple
+        /// instances of a service
+        /// default: 1
+        /// </summary>
+        public int? Index { get; set; }
+
+        /// <summary>
+        /// --env, -e
+        /// Set environment variables (can be used multiple times,
+        /// </summary>
+        /// <remarks>
+        /// Version: 1.25
+        /// </remarks>
+        public string[] Env { get; set; }
+
+        /// <summary>
+        /// --workdir, -w
+        /// Path to workdir directory for this command.
+        /// </summary>
+        public string Workdir { get; set; }
+    }
+}

--- a/src/Cake.Docker/Compose/Exec/args.txt
+++ b/src/Cake.Docker/Compose/Exec/args.txt
@@ -1,0 +1,10 @@
+﻿-d, --detach      Detached mode: Run command in the background.
+--privileged      Give extended privileges to the process.
+-u, --user USER   Run the command as this user.
+-T                Disable pseudo-tty allocation. By default `docker-compose exec`
+                  allocates a TTY.
+--index=index     index of the container if there are multiple
+                  instances of a service [default: 1]
+-e, --env KEY=VAL Set environment variables (can be used multiple times,
+                  not supported in API < 1.25)
+-w, --workdir DIR Path to workdir directory for this command.


### PR DESCRIPTION
Hi ✋ 

I am always helped by this add-in ❤️ 

The `docker-compose exec` command is now required, so I implemented that command.
I refer to the following documents and the implementation of `Docker.Aliases.Exec.cs`.
https://docs.docker.com/compose/reference/exec/

Since there is a description that `the actual code for settings is autogenerated from docker sources` in the README, I have not included the `DockeComposeExecSettings` file in this PR.

I'm sorry if it differs from the policy of this repository.

The `DockeComposeExecSettings` I used for the local test is below.

```csharp
namespace Cake.Docker
{
    /// <summary>
    /// Settings for docker-compose exec [options] [-e KEY=VAL...] SERVICE COMMAND [ARGS...]
    /// </summary>
    public sealed class DockerComposeExecSettings : DockerComposeSettings
    {
        /// <summary>
        /// -d, --detach
        /// Detached mode: Run command in the background.
        /// </summary>
        public bool? Detach { get; set; }

        /// <summary>
        /// --privileged
        /// Give extended privileges to the process.
        /// </summary>
        public bool? Privileged { get; set; }

        /// <summary>
        /// -u, --user USER
        /// Run the command as this user.
        /// </summary>
        public string User { get; set; }

        /// <summary>
        /// --index=index
        /// index of the container if there are multiple
        /// instances of a service
        /// default: 1
        /// </summary>
        public int? Index { get; set; }

        /// <summary>
        /// --env, -e
        /// Set environment variables (can be used multiple times,
        /// </summary>
        /// <remarks>
        /// Version: 1.25
        /// </remarks>
        public string[] Env { get; set; }

        /// <summary>
        /// --workdir, -w
        /// Path to workdir directory for this command.
        /// </summary>
        public string Workdir { get; set; }
    }
}