### PR TITLE
Bump dependencies

### DIFF
--- a/src/Cake.Docker.Tests/Build/DockerBuildFixture.cs
+++ b/src/Cake.Docker.Tests/Build/DockerBuildFixture.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Cake.Docker;
-using Cake.Testing.Fixtures;
-using Cake.Core;
+﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+using System;
 
 namespace Cake.Docker.Tests.Build
 {
@@ -24,6 +24,8 @@ namespace Cake.Docker.Tests.Build
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => throw new NotImplementedException();
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerBuildFixture(): base("docker")
         {

--- a/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
+++ b/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
@@ -8,10 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Cake" Version="0.33.0" />
     <PackageReference Include="Cake.Testing" Version="0.33.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="NSubstitute" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
+++ b/src/Cake.Docker.Tests/Cake.Docker.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake" Version="0.28.0" />
-    <PackageReference Include="Cake.Testing" Version="0.28.0" />
+    <PackageReference Include="Cake" Version="0.33.0" />
+    <PackageReference Include="Cake.Testing" Version="0.33.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />

--- a/src/Cake.Docker.Tests/Compose/Build/DockerComposeBuildFixture.cs
+++ b/src/Cake.Docker.Tests/Compose/Build/DockerComposeBuildFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
@@ -23,6 +24,8 @@ namespace Cake.Docker.Tests.Build
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => throw new NotImplementedException();
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerComposeBuildFixture(): base("docker-compose")
         {

--- a/src/Cake.Docker.Tests/Compose/Exec/DockerComposeExecFixture.cs
+++ b/src/Cake.Docker.Tests/Compose/Exec/DockerComposeExecFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
@@ -25,6 +26,8 @@ namespace Cake.Docker.Tests.Compose.Exec
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => Data;
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerComposeExecFixture() : base("docker-compose")
         {

--- a/src/Cake.Docker.Tests/Compose/Run/DockerComposeRunFixture.cs
+++ b/src/Cake.Docker.Tests/Compose/Run/DockerComposeRunFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
@@ -23,6 +24,8 @@ namespace Cake.Docker.Tests.Run
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => throw new NotImplementedException();
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerComposeRunFixture(): base("docker-compose")
         {

--- a/src/Cake.Docker.Tests/Ps/DockerPsFixture.cs
+++ b/src/Cake.Docker.Tests/Ps/DockerPsFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
 using Cake.Testing.Fixtures;
@@ -21,6 +22,8 @@ namespace Cake.Docker.Tests.Run
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => throw new NotImplementedException();
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerPsFixture(): base("docker")
         {

--- a/src/Cake.Docker.Tests/Registry/Login/DockerRegistryLoginFixture.cs
+++ b/src/Cake.Docker.Tests/Registry/Login/DockerRegistryLoginFixture.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Cake.Docker;
-using Cake.Testing.Fixtures;
-using Cake.Core;
+﻿using Cake.Core;
+using Cake.Core.Configuration;
 using Cake.Core.Diagnostics;
 using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+using System;
 
 namespace Cake.Docker.Tests.Build
 {
@@ -24,6 +24,8 @@ namespace Cake.Docker.Tests.Build
         public IRegistry Registry => Registry;
 
         public ICakeDataResolver Data => throw new NotImplementedException();
+
+        ICakeConfiguration ICakeContext.Configuration => throw new NotImplementedException();
 
         public DockerRegistryLoginFixture(): base("docker")
         {

--- a/src/Cake.Docker/Cake.Docker.csproj
+++ b/src/Cake.Docker/Cake.Docker.csproj
@@ -36,9 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.28.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #62. Example warning that would be fixed:
```
The assembly 'Cake.Docker, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (0.28.0). 
For best compatibility it should target Cake.Core version 0.33.0.
```
Also note that `Cake.Docker` is currently using version `0.0.0.0`.