### PR TITLE
Do not inherit specific tool settings from DockerComposeSettings

### DIFF
--- a/src/Cake.Docker/Compose/Port/DockerComposePortSettings.cs
+++ b/src/Cake.Docker/Compose/Port/DockerComposePortSettings.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Settings for docker-compose port.
     /// </summary>
-    public sealed class DockerComposePortSettings: DockerComposeSettings
+    public sealed class DockerComposePortSettings: AutoToolSettings
     {
         /// <summary>
         /// --index


### PR DESCRIPTION
I tried the beta version for the docker compose v2 branch and it worked fine. Thank you! The only thing I stumbled upon, was that the DockerComposePortSettings inherit from DockerComposeSettings while all others don't. Therefor I could pass the wrong settings type as a argument to the DockerComposePort alias.

#115 